### PR TITLE
Remove Vue Analytics from DOCS.md

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -14,7 +14,6 @@
 - [SnackBar](https://snackbar.egoist.sh/)
 - [Vue Meta](https://github.com/nuxt/vue-meta)
 - [Vue Directive Tooltip](https://hekigan.github.io/vue-directive-tooltip/)
-- [Vue Analytics](https://github.com/MatteoGabriele/vue-analytics)
 - [Axios](https://github.com/axios/axios)
 - [Kitsu](https://kitsu.docs.apiary.io/)
 - [rscss](https://rscss.io/)


### PR DESCRIPTION
# Story Title

[Remove the Vue Analytics documentation on DOCS.md](https://github.com/kuru-project/main-website/projects/2#card-25046229)

# Changes made

- Remove Vue Analytics from the DOCS.md

# How does the solution address the problem

This PR will remove Vue Analytics from the DOCS.md. We don't use it anymore.